### PR TITLE
Exporting Divisions to GeoJSON with turf

### DIFF
--- a/js/shared.js
+++ b/js/shared.js
@@ -1319,6 +1319,88 @@ function initSharedApp() {
       URL.revokeObjectURL(url);
     }
 
+    function exportDivionsAsGeoJSON() {
+      const statusElement = document.getElementById("geojson-export-status");
+
+      const bufferDist = 0.0001;
+
+      const divisions = divisionsAndGroups
+        .filter(entry => entry.type === 'division')
+        .reduce((accum, cur) => { accum[cur.name] = []; return accum; }, {});
+
+      sa1s.forEach((sa1) => divisions[sa1.properties.division].push(sa1));
+
+      const workerFn = function () {
+        self.importScripts('https://unpkg.com/@turf/turf@7/turf.min.js');
+
+        self.onmessage = function (e) {
+          const { divisions, bufferDist } = e.data;
+          const n_divisions = Object.keys(divisions).length;
+
+          Object.keys(divisions).forEach((key, index) => {
+            self.postMessage({ type: 'progress', message: `Processing ${key} (${index + 1}/${n_divisions})...` });
+
+            const features = divisions[key];
+            const featureCollection = turf.featureCollection(features);
+            const bufferedOut = turf.buffer(featureCollection, bufferDist, { units: 'degrees' });
+            const flattened = turf.flatten(bufferedOut);
+            const dissolved = turf.dissolve(flattened);
+            const bufferedIn = turf.buffer(dissolved, -bufferDist, { units: 'degrees' });
+            const combined = turf.combine(bufferedIn);
+            divisions[key] = combined.features[0];
+
+            divisions[key].properties = { name: key };
+          });
+
+          const fc = turf.featureCollection(Object.values(divisions));
+          self.postMessage({ type: 'done', fc });
+        };
+      };
+
+      const blob = new Blob(
+        [`(${workerFn.toString()})()`],
+        { type: 'application/javascript' }
+      );
+      const workerUrl = URL.createObjectURL(blob);
+      const worker = new Worker(workerUrl);
+      URL.revokeObjectURL(workerUrl);
+
+      worker.onmessage = function (e) {
+        const { type, message, fc } = e.data;
+          if (type === 'progress') {
+            statusElement.innerHTML = message;
+            return;
+          }
+
+          if (type === 'done') {
+            statusElement.innerHTML = 'Export complete!';
+            setTimeout(() => statusEl.remove(), 3000);
+            worker.terminate();
+
+            const jsonBlob = new Blob([JSON.stringify(fc)], { type: 'application/json' });
+            const url = URL.createObjectURL(jsonBlob);
+            const a = document.createElement('a');
+            const now = new Date();
+            const pad = n => String(n).padStart(2, '0');
+            const timestamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}_${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+            a.href = url;
+            a.download = `${window.EVENT_NAME}_districts_${timestamp}.geojson`;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+          }
+      };
+
+      worker.onerror = function (err) {
+        console.error('Worker error:', err);
+        worker.terminate();
+        statusElement.innerHTML = "GeoJSON export failed!";
+      };
+
+      worker.postMessage({ divisions, bufferDist });
+    }
+
     //==================//
     // IMPORT FROM CSV  //
     //==================//

--- a/state_nsw_2029.html
+++ b/state_nsw_2029.html
@@ -43,6 +43,8 @@
           <button class="button button-ghost" type="button" onclick="triggerImport()" title="Import SA1 allocation CSV">Import SA1s</button>
           <button class="button button-ghost" type="button" onclick="exportDivisionTotalsCSV()" title="Download per-district totals CSV">Export Districts</button>
           <button class="button button-ghost" type="button" onclick="unallocateDivisions()" title="Clear all districts from every SA1">Clear Divisions</button>
+          <button class="button button-ghost" type="button" style="grid-column: span 2;" onclick="exportDivionsAsGeoJSON()" title="Download per-district totals CSV">Export as GeoJSON</button>
+          <p id="geojson-export-status" style="grid-column: span 2; text-align: center; margin: 6px 2px 6px 2px"> Export Not Started</p>
           <input type="file" id="import-file" accept=".csv" style="display:none" />
         </div>
         <div id="header-info"></div>


### PR DESCRIPTION
Hi! Hope you're doing well. 

I don't know if this is a feature that would interest you, but in this PR I have added some code to allow for export of districts created via this site to a GeoJSON file. I've only put the button for this feature on the NSW state page as of yet.

I co-run a [political map simulation website](https://yapms.com/) in which you can import GeoJSON files to color as you wish. Some of our users also like using AU Redistribution, and wanted a way to import their custom districts into our site. I created a converter ([link](https://flizzy.dev/elections/auredistribution-to-geojson/)) for them based upon the SA1 CSV file, but it is a pain to keep updated with new SA1's.

Instead of a separate tool then, this code integrates directly into AU Redistribution itself and is generalizable - the shared function will work for any page. At a high-level, it collects all the SA1 geomtries assigned to a district by reading the Leaflet layer and combines them into a single geometry using [turf.js](https://turfjs.org/). Combining them involves several steps:
- [Buffering](https://turfjs.org/docs/api/buffer) all SA1s to avoid little gaps in the final geometries where SA1s do not exactly touch:
<img width="683" height="312" alt="image" src="https://github.com/user-attachments/assets/12ed155c-7e57-4a26-944d-c5d8a9a9ef4e" />

- [Flattening](https://turfjs.org/docs/api/flatten) SA1s by breaking them apart into contiguous parts. This is to allow for the next step.
- [Dissolving](https://turfjs.org/docs/api/dissolve) SA1s on their district property to combine adjacent SA1s that belong to the same district into one geometry.
- Unbuffering to restore shapes back to their original boundaries.
- [Combining](https://turfjs.org/docs/api/combine) the contiguous parts of each district back into one, potentially noncontiguous, feature.

This geospatial work is computationally expensive. To ensure the page does not hang, I utilize the web workers API to allow the UI thread to continue. Updates are shown as the web worker works to let the user know the process has not frozen. Error state and success state will also be communicated back.

![auRedis1](https://github.com/user-attachments/assets/6e85b4d2-a909-442a-b493-b555936e98bd)

<img width="504" height="58" alt="image" src="https://github.com/user-attachments/assets/33c88d99-1d18-4067-aaa1-88ff036fa53a" />

<img width="487" height="52" alt="image" src="https://github.com/user-attachments/assets/1c08fa41-a6c6-4b44-b512-0632c7a3f46a" />



turf.js is only loaded in if the user chooses to export to GeoJSON, primarily because web workers maintain their own script context, but it also means that page load time is not increased unneccessarily.

I'm writing this as it's late for me, so please do ask for clarification - I am sure I've missed something. I am happy to leave comments in the code as well, of course.